### PR TITLE
ci(pypi): live pypi

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,15 +36,15 @@ jobs:
         name: python-package-distributions
         path: dist/
 
-  publish-to-testpypi:
-    name: Publish Python distribution to TestPyPI
+  publish-to-pypi:
+    name: Publish Python distribution to PyPI
     needs:
     - build
     runs-on: ubuntu-latest
 
     environment:
       name: pypi
-      url: https://test.pypi.org/p/telicent-ies-tool
+      url: https://pypi.org/p/telicent-ies-tool
 
     permissions:
       id-token: write
@@ -56,7 +56,5 @@ jobs:
         name: python-package-distributions
         path: dist/
 
-    - name: Publish distribution to TestPyPI
+    - name: Publish distribution to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        repository-url: https://test.pypi.org/legacy/

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Python >= 3.8
 ## Install
 
 ```shell
-pip install git+https://github.com/telicent-oss/ies-tool.git
+pip install telicent-ies-tool
 ```
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telicent-ies-tool"
-version = "1.0.2"
+version = "1.0.1"
 authors = [{name = "Telicent Ltd", email = "opensource@telicent.io"}]
 description = "A library for working with the IES data standard"
 requires-python = ">=3.8"


### PR DESCRIPTION
Set to use Live PyPI.
Version number set back to 1.0.1 as 1.0.2 was only set due to TestPyPI needing unique version numbers. Live version will be 1.0.1.