### PR TITLE
fix: to allow plugins to work

### DIFF
--- a/ies_tool/ies_tool.py
+++ b/ies_tool/ies_tool.py
@@ -596,7 +596,9 @@ class IESTool:
             "validation_errors": "",
             "warnings": [],
         }
-        if self.__mode == "plugin":
+        if self.__mode == "sparql_server":
+            logger.warning("Export RDF not supported in sparql server mode")
+        elif self.__mode == "plugin":
             if rdf_format not in self.plug_in.supported_rdf_serialisations:
                 logger.warning(
                     f"Current plugin only supports {str(self.plug_in.supported_rdf_serialisations)}"
@@ -606,8 +608,6 @@ class IESTool:
             ret_dict["warnings"].extend(self.plug_in.get_warnings())
             if clear:
                 self.clear_graph()
-        if self.__mode == "sparql_server":
-            logger.warning("Export RDF not supported in sparql server mode")
         else:
             if self.__validate:
                 r = pyshacl_validate(


### PR DESCRIPTION
Hello - there was a small bug in the IES tool that prevented plug_in data from being saved. 

Please check I haven't borked anything by doing this. You might also want to check it works (it seems to for me). To check it, you'll need the fast_rdf  compiled .so file then run something like:

```python
from ies_tool.ies_tool import IESTool, Person

from fast_rdf import Fast


fast = Fast()
tool = IESTool(plug_in=fast,mode="plugin")


my_person = Person(
    tool=tool,
    given_name='Fred',
    surname='Smith',
    date_of_birth="1985-08-21"
)

tool.save_rdf('test.rdf')
```