### PR TITLE
perf!: Moved to short_uuid format to save space in messages

### DIFF
--- a/ies_tool/ies_tool.py
+++ b/ies_tool/ies_tool.py
@@ -5,7 +5,7 @@ import json
 import logging
 import os
 import pathlib
-import uuid
+import shortuuid
 import warnings
 from typing import TypeVar
 
@@ -218,7 +218,7 @@ class IESTool:
 
 
         self.session_uuid_str = None
-        self.session_uuid = None
+
         self.current_dir = pathlib.Path(__file__).parent.resolve()
 
         local_folder = os.path.dirname(os.path.realpath(__file__))
@@ -264,7 +264,7 @@ class IESTool:
         self.graph = Graph()
 
         self.prefixes: dict[str, str] = {}
-        self.add_prefix(":",IES_BASE)
+        self.add_prefix("ies:",IES_BASE)
         self.default_data_namespace = default_data_namespace
 
 
@@ -475,7 +475,7 @@ class IESTool:
         self.shacl.parse(shacl_filename)
         logger.info("SHACL ready")
 
-    def clear_graph(self) -> uuid.UUID:
+    def clear_graph(self) -> str:
         """
         Clears the graph currently in use. This is the quickest way to run repeated IES data runs - far quicker
         than constantly initiating new IESTool objects
@@ -494,11 +494,11 @@ class IESTool:
             self.graph = Graph()
             for prefix in self.prefixes:
                 self.graph.bind(prefix.replace(":", ""), self.prefixes[prefix])
-        self.session_uuid = uuid.uuid4()
-        self.session_uuid_str = self.session_uuid.hex
+        self.session_uuid_str = shortuuid.uuid()
+
         self.session_instance_count = 0
         self.instances = {}
-        return self.session_uuid
+        return self.session_uuid_str
 
     def run_sparql_update(self, query: str, security_label: str | None = None):
         """
@@ -653,7 +653,7 @@ class IESTool:
         """
 
         ret_dict: dict[str, str | list] = {
-            "session_uuid": self.session_uuid,
+            "session_uuid": self.session_uuid_str,
             "triples": "",
             "validation_errors": ""
         }

--- a/ies_tool/ies_tool.py
+++ b/ies_tool/ies_tool.py
@@ -279,6 +279,7 @@ class IESTool:
 
         self.prefixes: dict[str, str] = {}
         self.add_prefix("ies:", IES_BASE)
+        self.add_prefix(":", default_data_namespace)
         self.default_data_namespace = default_data_namespace
 
         # Test that the default data stub generates valid URIs

--- a/ies_tool/ies_tool.py
+++ b/ies_tool/ies_tool.py
@@ -113,6 +113,7 @@ DEFAULT_PREFIXES = {
     "rfc5322:": "https://ietf.org/rfc5322#",
     "ieee802:": "https://www.ieee802.org#",
     "ies:": IES_BASE,
+    ":": "http://example.com/rdf/testdata#"
 }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "pycountry==24.6.1",
     "validators==0.28.1",
     "iso4217parse==0.5.1",
-    "shortuuid=1.0.13"
+    "shortuuid==1.0.13"
 ]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,8 @@ dependencies = [
     "phonenumbers==8.13.35",
     "pycountry==24.6.1",
     "validators==0.28.1",
-    "iso4217parse==0.5.1"
+    "iso4217parse==0.5.1",
+    "shortuuid=1.0.13"
 ]
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
Hi Daniel,

Trying to save a bit of space and get some incremental performance gains. This is pretty minor - just switches the current base16 uuid encoding to alphanumeric (base54 ?). Anyways, it saves a bit.

Two potential breaking changes - clear_graph now returns a string not a UUID (I don't think anyone uses this), and the return dictionary also has a string not a UUID...again I don't think the data team were using this. @afizzycola - can you confirm these are not used ?

Also spotted a bug - assigning the wrong default prefix.

Ta

Ian