### PR TITLE
fix: typo in plug-in stub functions

### DIFF
--- a/ies_tool/ies_plugin.py
+++ b/ies_tool/ies_plugin.py
@@ -70,7 +70,7 @@ class IESPlugin:
     def get_triple_count(self) -> int:
         raise NotImplementedError
 
-    def can_suppport_prefixes(self) -> bool:
+    def can_support_prefixes(self) -> bool :
         raise NotImplementedError
 
     def add_prefix(self, prefix: str, uri: str):


### PR DESCRIPTION
too many p's