### PR TITLE
fix!: default data namespace setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,4 @@ cython_debug/
 # OS-X proof
 .DS_Store
 .vscode
+/*.ttl

--- a/ies_tool/ies_constants.py
+++ b/ies_tool/ies_constants.py
@@ -4,6 +4,7 @@ RDF_TYPE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
 RDFS_CLASS = "http://www.w3.org/2000/01/rdf-schema#Class"
 
 IES_BASE = "http://ies.data.gov.uk/ontology/ies4#"
+DEFAULT_DATA_NAMESPACE = "http://example.com/rdf/testdata#"
 
 TELICENT_PRIMARY_NAME = "http://telicent.io/ontology/primaryName"
 

--- a/ies_tool/ies_constants.py
+++ b/ies_tool/ies_constants.py
@@ -67,5 +67,5 @@ DEFAULT_PREFIXES = {
     "rfc5322:": "https://ietf.org/rfc5322#",
     "ieee802:": "https://www.ieee802.org#",
     "ies:": IES_BASE,
-    ":": "http://example.com/rdf/testdata#",
+    ":": DEFAULT_DATA_NAMESPACE,
 }

--- a/ies_tool/ies_plugin.py
+++ b/ies_tool/ies_plugin.py
@@ -18,7 +18,7 @@ limitations under the License.
 class IESPlugin:
 
     def __init__(self, default_data_namespace: str = "https://telicent.io/testdata#"):
-        self.default_data_namespace: str = default_data_namespace
+        self._default_data_namespace: str = default_data_namespace
 
     def generate_data_uri(self, context: str | None = None) -> str:
         raise NotImplementedError

--- a/ies_tool/ies_plugin.py
+++ b/ies_tool/ies_plugin.py
@@ -1,3 +1,5 @@
+import ies_tool.ies_constants as ies_constants
+
 __license__ = """
 Copyright TELICENT LTD
 
@@ -24,7 +26,7 @@ class IESPlugin:
     the property getter/setter pattern.
     """
 
-    def __init__(self, default_data_namespace: str = "https://telicent.io/testdata#"):
+    def __init__(self, default_data_namespace: str = ies_constants.DEFAULT_DATA_NAMESPACE):
         _ = default_data_namespace  # Parameter kept for interface consistency
 
     def generate_data_uri(self, context: str | None = None) -> str:

--- a/ies_tool/ies_plugin.py
+++ b/ies_tool/ies_plugin.py
@@ -20,10 +20,6 @@ limitations under the License.
 class IESPlugin:
     """
     Abstract base class for IES storage plugins.
-
-    Subclasses of such must implement all abstract methods and properties, including
-    proper initialization of default_data_namespace to avoid conflicts with
-    the property getter/setter pattern.
     """
 
     def __init__(self, default_data_namespace: str = ies_constants.DEFAULT_DATA_NAMESPACE):

--- a/ies_tool/ies_plugin.py
+++ b/ies_tool/ies_plugin.py
@@ -16,9 +16,16 @@ limitations under the License.
 
 
 class IESPlugin:
+    """
+    Abstract base class for IES storage plugins.
+
+    Subclasses of such must implement all abstract methods and properties, including
+    proper initialization of default_data_namespace to avoid conflicts with
+    the property getter/setter pattern.
+    """
 
     def __init__(self, default_data_namespace: str = "https://telicent.io/testdata#"):
-        self._default_data_namespace: str = default_data_namespace
+        _ = default_data_namespace  # Parameter kept for interface consistency
 
     def generate_data_uri(self, context: str | None = None) -> str:
         raise NotImplementedError

--- a/ies_tool/ies_plugin.py
+++ b/ies_tool/ies_plugin.py
@@ -27,7 +27,7 @@ class IESPlugin:
     """
 
     def __init__(self, default_data_namespace: str = ies_constants.DEFAULT_DATA_NAMESPACE):
-        _ = default_data_namespace  # Parameter kept for interface consistency
+        self._default_data_namespace = default_data_namespace
 
     def generate_data_uri(self, context: str | None = None) -> str:
         raise NotImplementedError
@@ -90,11 +90,11 @@ class IESPlugin:
 
     @property
     def default_data_namespace(self):
-        raise NotImplementedError
+        return self._default_data_namespace
 
     @default_data_namespace.setter
     def default_data_namespace(self, value: str):
-        raise NotImplementedError
+        self._default_data_namespace = value
 
     @property
     def supported_rdf_serialisations(self) -> list:

--- a/ies_tool/ies_tool.py
+++ b/ies_tool/ies_tool.py
@@ -168,11 +168,12 @@ class IESTool:
 
         # Resolve the effective default_data_namespace:
         # 1. If explicitly provided to IESTool, use it
-        # 2. If a plugin is provided and has a non-default namespace, use the plugin's
+        # 2. If a plugin is provided and supports default_data_namespace, use the plugin's
         # 3. Otherwise, use the constant default
         if default_data_namespace is not None:
             effective_namespace = default_data_namespace
-        elif self.__mode == "plugin" and self.plug_in is not None:
+        elif (self.__mode == "plugin" and self.plug_in is not None
+              and hasattr(self.plug_in, 'default_data_namespace')):
             effective_namespace = self.plug_in.default_data_namespace
         else:
             effective_namespace = ies_constants.DEFAULT_DATA_NAMESPACE

--- a/ies_tool/ies_tool.py
+++ b/ies_tool/ies_tool.py
@@ -212,7 +212,9 @@ class IESTool:
         # Update the plugin's namespace to match IESTool's resolved namespace
         # This must happen before clear_graph() which uses the plugin's namespace
         if self.__mode == "plugin" and self.plug_in is not None:
-            self.plug_in.default_data_namespace = default_data_namespace
+            # Only set if the plugin supports the default_data_namespace property
+            if hasattr(self.plug_in, 'default_data_namespace'):
+                self.plug_in.default_data_namespace = default_data_namespace
 
         # Test that the default data stub generates valid URIs
 

--- a/ies_tool/ies_tool.py
+++ b/ies_tool/ies_tool.py
@@ -64,7 +64,7 @@ class IESTool:
 
     def __init__(
         self,
-        default_data_namespace: str | None = None,
+        default_data_namespace: str | None = None, # actual default URI resolved later
         mode: str = "rdflib",
         plug_in: IESPlugin | None = None,
         validate: bool = False,

--- a/ies_tool/ies_tool.py
+++ b/ies_tool/ies_tool.py
@@ -64,7 +64,7 @@ class IESTool:
 
     def __init__(
         self,
-        default_data_namespace: str | None = None, # actual default URI resolved later
+        default_data_namespace: str | None = None,
         mode: str = "rdflib",
         plug_in: IESPlugin | None = None,
         validate: bool = False,

--- a/ies_tool/ies_tool.py
+++ b/ies_tool/ies_tool.py
@@ -64,7 +64,7 @@ class IESTool:
 
     def __init__(
         self,
-        default_data_namespace: str = ies_constants.DEFAULT_DATA_NAMESPACE,
+        default_data_namespace: str | None = None,
         mode: str = "rdflib",
         plug_in: IESPlugin | None = None,
         validate: bool = False,
@@ -158,9 +158,25 @@ class IESTool:
 
         self.ontology = Ontology(ont_file, additional_classes=additional_classes)
 
+        # Auto-detect plugin mode if a plugin is provided
+        if plug_in is not None and mode == "rdflib":
+            mode = "plugin"
+
         self.__mode = mode
         if mode not in ["rdflib"]:
             self._register_plugin(mode, plug_in)
+
+        # Resolve the effective default_data_namespace:
+        # 1. If explicitly provided to IESTool, use it
+        # 2. If a plugin is provided and has a non-default namespace, use the plugin's
+        # 3. Otherwise, use the constant default
+        if default_data_namespace is not None:
+            effective_namespace = default_data_namespace
+        elif self.__mode == "plugin" and self.plug_in is not None:
+            effective_namespace = self.plug_in.default_data_namespace
+        else:
+            effective_namespace = ies_constants.DEFAULT_DATA_NAMESPACE
+        default_data_namespace = effective_namespace
 
         if self.__mode == "plugin":
             logger.info("Using a user-defined storage plugin")
@@ -193,12 +209,19 @@ class IESTool:
         self.add_prefix(":", default_data_namespace)
         self.default_data_namespace = default_data_namespace
 
+        # Update the plugin's namespace to match IESTool's resolved namespace
+        # This must happen before clear_graph() which uses the plugin's namespace
+        if self.__mode == "plugin" and self.plug_in is not None:
+            self.plug_in.default_data_namespace = default_data_namespace
+
         # Test that the default data stub generates valid URIs
 
         self.check_valid_uri_production()
         # Establish a set of useful prefixes
         for k, v in ies_constants.DEFAULT_PREFIXES.items():
-            self.add_prefix(k, v)
+            # Skip ":" since it was already set above with the resolved default_data_namespace
+            if k != ":":
+                self.add_prefix(k, v)
 
         self.clear_graph()
 

--- a/ies_tool/ies_tool.py
+++ b/ies_tool/ies_tool.py
@@ -64,7 +64,7 @@ class IESTool:
 
     def __init__(
         self,
-        default_data_namespace: str = "http://example.com/rdf/testdata#",
+        default_data_namespace: str = ies_constants.DEFAULT_DATA_NAMESPACE,
         mode: str = "rdflib",
         plug_in: IESPlugin | None = None,
         validate: bool = False,

--- a/ies_tool/rdflib_plugin.py
+++ b/ies_tool/rdflib_plugin.py
@@ -2,6 +2,8 @@ import shortuuid
 from rdflib import XSD, Graph, Literal, Namespace, URIRef
 from rdflib.namespace import NamespaceManager
 
+import ies_tool.ies_constants as ies_constants
+
 __license__ = """
 Copyright TELICENT LTD
 
@@ -21,11 +23,11 @@ limitations under the License.
 
 class RdfLibPlugin:
 
-    def __init__(self, default_data_namespace: str = "https://telicent.io/testdata#"):
+    def __init__(self, default_data_namespace: str = ies_constants.DEFAULT_DATA_NAMESPACE):
         """Creates an instance of the RdfLibPlugin class - a serialisation plugin that uses rdflib to manage RDF data.
 
         Args:
-            default_data_namespace (_type_, optional): _description_. Defaults to "https://telicent.io/testdata#".
+            default_data_namespace: The default URI namespace for generated data.
         """
         self._supported_rdf_serialisations = [
             "turtle",

--- a/ies_tool/rdflib_plugin.py
+++ b/ies_tool/rdflib_plugin.py
@@ -212,7 +212,7 @@ class RdfLibPlugin:
         """
         return len(self.graph)
 
-    def can_suppport_prefixes(self) -> bool:
+    def can_support_prefixes(self) -> bool:
         """Indicates if the plugin can support prefixes in the RDF graph.
 
         Returns:
@@ -227,7 +227,7 @@ class RdfLibPlugin:
             prefix (str): _description_
             uri (str): _description_
         """
-        self.namespace_manager.bind(prefix.replace(":", ""), Namespace(uri))
+        self.namespace_manager.bind(prefix.replace(":", ""), Namespace(uri), replace=True)
 
     def get_namespace_uri(self, prefix: str) -> str:
         """

--- a/ies_tool/sparql_endpoint_plugin.py
+++ b/ies_tool/sparql_endpoint_plugin.py
@@ -28,7 +28,7 @@ class SPARQLEndpointPlugin:
         ser_user: str = "",
         server_password: str = "",
     ):
-        self.default_data_namespace: str = default_data_namespace
+        self._default_data_namespace: str = default_data_namespace
         self.server_host: str = server_host
         self.server_dataset: str = server_dataset
         self.ser_user: str = ser_user

--- a/ies_tool/sparql_endpoint_plugin.py
+++ b/ies_tool/sparql_endpoint_plugin.py
@@ -1,6 +1,8 @@
 import requests
 import shortuuid
 
+import ies_tool.ies_constants as ies_constants
+
 __license__ = """
 Copyright TELICENT LTD
 
@@ -22,7 +24,7 @@ class SPARQLEndpointPlugin:
 
     def __init__(
         self,
-        default_data_namespace: str = "https://telicent.io/testdata#",
+        default_data_namespace: str = ies_constants.DEFAULT_DATA_NAMESPACE,
         server_host: str = "http://localhost:3030/",
         server_dataset: str = "ds",
         ser_user: str = "",

--- a/ies_tool/sparql_endpoint_plugin.py
+++ b/ies_tool/sparql_endpoint_plugin.py
@@ -206,11 +206,11 @@ class SPARQLEndpointPlugin:
 
     @property
     def default_data_namespace(self):
-        raise NotImplementedError
+        return self._default_data_namespace
 
     @default_data_namespace.setter
     def default_data_namespace(self, value: str):
-        raise NotImplementedError
+        self._default_data_namespace = value
 
     @property
     def supported_rdf_serialisations(self) -> list:

--- a/ies_tool/sparql_endpoint_plugin.py
+++ b/ies_tool/sparql_endpoint_plugin.py
@@ -197,7 +197,7 @@ class SPARQLEndpointPlugin:
     def get_triple_count(self) -> int:
         raise NotImplementedError
 
-    def can_suppport_prefixes(self) -> bool:
+    def can_support_prefixes(self) -> bool:
         return False
 
     def add_prefix(self, prefix: str, uri: str):

--- a/test/test_default_data_namespace.py
+++ b/test/test_default_data_namespace.py
@@ -3,7 +3,6 @@ import unittest
 import ies_tool.ies_constants as ies_constants
 import ies_tool.ies_tool as ies
 from ies_tool.rdflib_plugin import RdfLibPlugin
-from ies_tool.sparql_endpoint_plugin import SPARQLEndpointPlugin
 
 
 class TestDefaultDataNamespace(unittest.TestCase):
@@ -85,7 +84,7 @@ class TestDefaultDataNamespace(unittest.TestCase):
         """
         custom_namespace = "http://custom.example.org/data#"
         plugin = RdfLibPlugin()
-        tool = ies.IESTool(mode=plugin, default_data_namespace=custom_namespace)
+        tool = ies.IESTool(plug_in=plugin, default_data_namespace=custom_namespace)
 
         self.assertEqual(
             tool.default_data_namespace,
@@ -101,7 +100,7 @@ class TestDefaultDataNamespace(unittest.TestCase):
         """
         custom_namespace = "http://custom.example.org/data#"
         plugin = RdfLibPlugin(default_data_namespace=custom_namespace)
-        tool = ies.IESTool(mode=plugin)
+        tool = ies.IESTool(plug_in=plugin, mode="plugin")
 
         self.assertEqual(
             tool.default_data_namespace,
@@ -117,7 +116,7 @@ class TestDefaultDataNamespace(unittest.TestCase):
         custom_namespace_1 = "http://custom.example.org/data1#"
         custom_namespace_2 = "http://custom.example.org/data2#"
         plugin = RdfLibPlugin(default_data_namespace=custom_namespace_1)
-        tool = ies.IESTool(mode=plugin, default_data_namespace=custom_namespace_2)
+        tool = ies.IESTool(plug_in=plugin, default_data_namespace=custom_namespace_2)
 
         self.assertEqual(
             tool.default_data_namespace,
@@ -154,41 +153,6 @@ class TestDefaultDataNamespace(unittest.TestCase):
             "RdfLibPlugin should return the namespace via property getter"
         )
 
-
-    def test_all_classes_use_same_constant(self):
-        """
-        All classes use the DEFAULT_DATA_NAMESPACE constant.
-        """
-        import inspect
-
-        # Check IESTool
-        ies_tool_sig = inspect.signature(ies.IESTool.__init__)
-        ies_tool_default = ies_tool_sig.parameters['default_data_namespace'].default
-
-        # Check RdfLibPlugin
-        rdflib_sig = inspect.signature(RdfLibPlugin.__init__)
-        rdflib_default = rdflib_sig.parameters['default_data_namespace'].default
-
-        # Check SPARQLEndpointPlugin
-        sparql_sig = inspect.signature(SPARQLEndpointPlugin.__init__)
-        sparql_default = sparql_sig.parameters['default_data_namespace'].default
-
-        # All should equal the constant
-        self.assertEqual(
-            ies_tool_default,
-            ies_constants.DEFAULT_DATA_NAMESPACE,
-            "IESTool should use DEFAULT_DATA_NAMESPACE constant"
-        )
-        self.assertEqual(
-            rdflib_default,
-            ies_constants.DEFAULT_DATA_NAMESPACE,
-            "RdfLibPlugin should use DEFAULT_DATA_NAMESPACE constant"
-        )
-        self.assertEqual(
-            sparql_default,
-            ies_constants.DEFAULT_DATA_NAMESPACE,
-            "SPARQLEndpointPlugin should use DEFAULT_DATA_NAMESPACE constant"
-        )
 
     def test_generated_uris_use_configured_namespace(self):
         """

--- a/test/test_default_data_namespace.py
+++ b/test/test_default_data_namespace.py
@@ -1,0 +1,211 @@
+import unittest
+
+import ies_tool.ies_constants as ies_constants
+import ies_tool.ies_tool as ies
+from ies_tool.rdflib_plugin import RdfLibPlugin
+from ies_tool.sparql_endpoint_plugin import SPARQLEndpointPlugin
+
+
+class TestDefaultDataNamespace(unittest.TestCase):
+    """
+    Tests for default_data_namespace functionality across IESTool and plugin classes.
+    """
+
+    def test_default_namespace_constant_value(self):
+        """
+        Verify the DEFAULT_DATA_NAMESPACE constant is set correctly.
+        The constant should be "http://example.com/rdf/testdata#" as documented in the README.
+        """
+        self.assertEqual(
+            ies_constants.DEFAULT_DATA_NAMESPACE,
+            "http://example.com/rdf/testdata#",
+            "DEFAULT_DATA_NAMESPACE constant should match the documented default"
+        )
+
+    def test_iestool_default_namespace_when_mode_not_set(self):
+        """
+        When mode is not explicitly stated on init (defaults to "rdflib"),
+        default_data_namespace should use the constant value.
+        """
+        tool = ies.IESTool()  # mode defaults to "rdflib"
+
+        self.assertEqual(
+            tool.default_data_namespace,
+            ies_constants.DEFAULT_DATA_NAMESPACE,
+            "IESTool should use DEFAULT_DATA_NAMESPACE constant when mode is not set"
+        )
+
+
+    def test_iestool_default_namespace_when_mode_set(self):
+        """
+        When mode is explicitly stated on init to "rdflib",
+        default_data_namespace should use the constant value.
+        """
+        tool = ies.IESTool(mode="rdflib")
+
+        self.assertEqual(
+            tool.default_data_namespace,
+            ies_constants.DEFAULT_DATA_NAMESPACE,
+            "IESTool should use DEFAULT_DATA_NAMESPACE constant when mode is not set"
+        )
+
+    def test_iestool_namespace_set_when_mode_not_set(self):
+        """
+        When mode is not explicitly stated on init (defaults to "rdflib"),
+        and a custom namespace is provided, it should be respected.
+        """
+        custom_namespace = "http://custom.example.org/data#"
+        tool = ies.IESTool(default_data_namespace=custom_namespace)  # mode defaults to "rdflib"
+
+        self.assertEqual(
+            tool.default_data_namespace,
+            custom_namespace,
+            "IESTool should use custom namespace provided by user"
+        )
+
+
+    def test_iestool_namespace_set_when_mode_set(self):
+        """
+        When mode is explicitly stated on init to "rdflib",
+        and a custom namespace is provided, it should be respected.
+        """
+        custom_namespace = "http://custom.example.org/data#"
+        tool = ies.IESTool(mode="rdflib", default_data_namespace=custom_namespace)
+
+        self.assertEqual(
+            tool.default_data_namespace,
+            custom_namespace,
+            "IESTool should use custom namespace provided by user"
+        )
+
+    def test_iestool_namespace_set_with_plugin(self):
+        """
+        When a custom namespace is provided during initialisation alongside
+        custom plugin, it should override the default value.
+        """
+        custom_namespace = "http://custom.example.org/data#"
+        plugin = RdfLibPlugin()
+        tool = ies.IESTool(mode=plugin, default_data_namespace=custom_namespace)
+
+        self.assertEqual(
+            tool.default_data_namespace,
+            custom_namespace,
+            "IESTool should use the user-provided namespace, not the default"
+        )
+
+    def test_iestool_namespace_set_with_one_set_in_plugin(self):
+        """
+        When a custom namespace is provided when init a custom plugin and
+        one not set on init IESTool, then the one set in the plugin shall
+        override the default value.
+        """
+        custom_namespace = "http://custom.example.org/data#"
+        plugin = RdfLibPlugin(default_data_namespace=custom_namespace)
+        tool = ies.IESTool(mode=plugin)
+
+        self.assertEqual(
+            tool.default_data_namespace,
+            custom_namespace,
+            "RdfLibPlugin should use the user-provided namespace, not the default"
+        )
+
+    def test_iestool_namespace_overrides_one_set_in_plugin(self):
+        """
+        When a custom namespace is provided in both the init of RdfLibPlugin
+        and IESTool, the IESTool one prevails.
+        """
+        custom_namespace_1 = "http://custom.example.org/data1#"
+        custom_namespace_2 = "http://custom.example.org/data2#"
+        plugin = RdfLibPlugin(default_data_namespace=custom_namespace_1)
+        tool = ies.IESTool(mode=plugin, default_data_namespace=custom_namespace_2)
+
+        self.assertEqual(
+            tool.default_data_namespace,
+            custom_namespace_2,
+            "IESTool should use its own namespace parameter, overriding the plugin's"
+        )
+
+    def test_rdflib_plugin_namespace_setter_works(self):
+        """
+        Verify RdfLibPlugin property setter works.
+        """
+        plugin = RdfLibPlugin()
+        new_namespace = "http://updated.test.org/data#"
+
+        # This should not raise NotImplementedError
+        plugin.default_data_namespace = new_namespace
+
+        self.assertEqual(
+            plugin.default_data_namespace,
+            new_namespace,
+            "RdfLibPlugin should allow updating namespace via property setter"
+        )
+
+    def test_rdflib_plugin_namespace_getter_works(self):
+        """
+        Verify RdfLibPlugin property getter works.
+        """
+        new_namespace = "http://updated.test.org/data#"
+        plugin = RdfLibPlugin(default_data_namespace=new_namespace)
+
+        self.assertEqual(
+            plugin.default_data_namespace,
+            new_namespace,
+            "RdfLibPlugin should return the namespace via property getter"
+        )
+
+
+    def test_all_classes_use_same_constant(self):
+        """
+        All classes use the DEFAULT_DATA_NAMESPACE constant.
+        """
+        import inspect
+
+        # Check IESTool
+        ies_tool_sig = inspect.signature(ies.IESTool.__init__)
+        ies_tool_default = ies_tool_sig.parameters['default_data_namespace'].default
+
+        # Check RdfLibPlugin
+        rdflib_sig = inspect.signature(RdfLibPlugin.__init__)
+        rdflib_default = rdflib_sig.parameters['default_data_namespace'].default
+
+        # Check SPARQLEndpointPlugin
+        sparql_sig = inspect.signature(SPARQLEndpointPlugin.__init__)
+        sparql_default = sparql_sig.parameters['default_data_namespace'].default
+
+        # All should equal the constant
+        self.assertEqual(
+            ies_tool_default,
+            ies_constants.DEFAULT_DATA_NAMESPACE,
+            "IESTool should use DEFAULT_DATA_NAMESPACE constant"
+        )
+        self.assertEqual(
+            rdflib_default,
+            ies_constants.DEFAULT_DATA_NAMESPACE,
+            "RdfLibPlugin should use DEFAULT_DATA_NAMESPACE constant"
+        )
+        self.assertEqual(
+            sparql_default,
+            ies_constants.DEFAULT_DATA_NAMESPACE,
+            "SPARQLEndpointPlugin should use DEFAULT_DATA_NAMESPACE constant"
+        )
+
+    def test_generated_uris_use_configured_namespace(self):
+        """
+        Generated URIs use the configured default_data_namespace.
+        """
+        custom_namespace = "http://myorg.example.com/data#"
+        tool = ies.IESTool(default_data_namespace=custom_namespace)
+
+        # Create a person
+        person = ies.Person(tool=tool, given_name="Bob", surname="Smith")
+
+        # Verify the person's URI starts with the custom namespace
+        self.assertTrue(
+            person.uri.startswith(custom_namespace),
+            f"Generated URI should start with {custom_namespace}, but got {person.uri}"
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_prefixes.py
+++ b/test/test_prefixes.py
@@ -1,0 +1,65 @@
+import unittest
+
+import ies_tool.ies_constants as ies_constants
+import ies_tool.ies_tool as ies
+from ies_tool.rdflib_plugin import RdfLibPlugin
+
+
+class TestPrefixSetting(unittest.TestCase):
+
+    def test_iestool_namespace_sets_default_prefix_on_init(self):
+        """
+        Verify that setting default_data_namespace on IESTool init
+        automatically assigns this namespace to the default prefix (:).
+        """
+        custom_namespace = "http://test.example.com/mydata#"
+        tool = ies.IESTool(default_data_namespace=custom_namespace)
+
+        # Check that the ":" prefix is set to the custom namespace
+        self.assertEqual(
+            tool.prefixes[":"],
+            custom_namespace,
+            "The ':' prefix should be set to match default_data_namespace"
+        )
+
+    def test_iestool_namespace_prefix_updates_on_change(self):
+        """
+        When the namespace is changed after initialisation, the ":" prefix should
+        automatically update to match.
+        """
+        tool = ies.IESTool()
+
+        # Verify initial state
+        self.assertEqual(tool.prefixes[":"], ies_constants.DEFAULT_DATA_NAMESPACE)
+
+        # Change the namespace
+        new_namespace = "http://changed.example.org/newdata#"
+        tool.default_data_namespace = new_namespace
+
+        # Verify the ":" prefix updated automatically
+        self.assertEqual(
+            tool.prefixes[":"],
+            new_namespace,
+            "The ':' prefix should automatically update when default_data_namespace changes"
+        )
+
+    def test_rdflib_plugin_prefix_updates_on_namespace_change(self):
+        """
+        Verify RdfLibPlugin updates ":" prefix when namespace changes.
+        """
+        plugin = RdfLibPlugin()
+        new_namespace = "http://plugin.updated.org/data#"
+
+        # Change the namespace
+        plugin.default_data_namespace = new_namespace
+
+        # Verify the ":" prefix was updated
+        namespace_uri = plugin.get_namespace_uri(":")
+        self.assertEqual(
+            namespace_uri,
+            new_namespace,
+            "RdfLibPlugin should update ':' prefix when namespace is set"
+        )
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Main fixes made in this PR:
1. upon `IESTool` init, when `default_data_namespace` is assigned and `mode="rdflib"` is not explicitly stated, the `default_data_namespace` (`http://example.com/rdf/testdata#`) is not overwritten by the one provided by the user
2. When `default_data_namespace` is set, this does not automatically assign this namespace to the default namespace prefix (`:`)
3. default for `default_data_namespace`  implemented as a CONSTANT to prevent inconsistent hardcoding across code-base

Additional fixes:
5. Auto-detect plugin mode when `plug_in` is provided on `IESTool()` init, but `mode` isn't set
6. Fix typo in `can_support_prefixes()` method